### PR TITLE
Add standalone frontend and revert template changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ python frontend/server.py
 Then open `http://127.0.0.1:5000/` in a browser and drop a PDF onto the page.
 The app posts the file to `/api/ocr` and displays Markdown for each page with
 **Copy MD** and **Download MD** buttons. Use **Download All** to save every page
-as a zip archive.
+as a zip archive. The server reads the PDF asynchronously so large files won't
+block other requests.
 
 
 ### Full documentation for the pipeline

--- a/README.md
+++ b/README.md
@@ -242,10 +242,11 @@ python frontend/server.py
 ```
 
 Then open `http://127.0.0.1:5000/` in a browser and drop a PDF onto the page.
-The app posts the file to `/api/ocr` and displays Markdown for each page with
-**Copy MD** and **Download MD** buttons. Use **Download All** to save every page
-as a zip archive. The server reads the PDF asynchronously so large files won't
-block other requests.
+The app posts the file to `/api/ocr` where each page is sent to a local OCR
+service. `PdfReader` is only used to determine the number of pages. The returned
+Markdown is rendered on the page along with **Copy MD** and **Download MD**
+buttons. Use **Download All** to save every page as a zip archive. The server
+uses asynchronous helpers so large uploads won't block other requests.
 
 
 ### Full documentation for the pipeline

--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ python -m olmocr.pipeline ./localworkspace --markdown --pdfs olmocr-sample.pdf
 ```
 > You can also visit our Docker repository on [Docker Hub](https://hub.docker.com/r/alleninstituteforai/olmocr).
 
+### Simple Frontend
+
+A minimal drag-and-drop UI is provided under `frontend/`. Open `index.html` in a browser and drop a PDF onto the page. The app posts the file to `/api/ocr` and displays Markdown for each page with **Copy MD** and **Download MD** buttons. Use **Download All** to save every page as a zip archive.
+
+
 ### Full documentation for the pipeline
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -235,7 +235,16 @@ python -m olmocr.pipeline ./localworkspace --markdown --pdfs olmocr-sample.pdf
 
 ### Simple Frontend
 
-A minimal drag-and-drop UI is provided under `frontend/`. Open `index.html` in a browser and drop a PDF onto the page. The app posts the file to `/api/ocr` and displays Markdown for each page with **Copy MD** and **Download MD** buttons. Use **Download All** to save every page as a zip archive.
+A minimal drag-and-drop UI is provided under `frontend/`. Start it with
+
+```bash
+python frontend/server.py
+```
+
+Then open `http://127.0.0.1:5000/` in a browser and drop a PDF onto the page.
+The app posts the file to `/api/ocr` and displays Markdown for each page with
+**Copy MD** and **Download MD** buttons. Use **Download All** to save every page
+as a zip archive.
 
 
 ### Full documentation for the pipeline

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -43,7 +43,11 @@ function renderPages() {
   pages.forEach((text, i) => {
     const div = document.createElement('div');
     div.className = 'page-result';
-    div.innerHTML = `<h3>Page ${i + 1}</h3><pre>${text}</pre>`;
+    const md = document.createElement('div');
+    md.className = 'markdown';
+    md.innerHTML = marked.parse(text);
+    div.innerHTML = `<h3>Page ${i + 1}</h3>`;
+    div.appendChild(md);
     const actions = document.createElement('div');
     actions.className = 'page-actions';
     const copyBtn = document.createElement('button');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,88 @@
+const dropZone = document.getElementById('drop-zone');
+const results = document.getElementById('results');
+const allDownloadBtn = document.getElementById('all-download');
+let pages = [];
+
+function preventDefaults(e) {
+  e.preventDefault();
+  e.stopPropagation();
+}
+['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+  dropZone.addEventListener(eventName, preventDefaults, false);
+});
+['dragenter', 'dragover'].forEach(eventName => {
+  dropZone.addEventListener(eventName, () => dropZone.classList.add('hover'), false);
+});
+['dragleave', 'drop'].forEach(eventName => {
+  dropZone.addEventListener(eventName, () => dropZone.classList.remove('hover'), false);
+});
+
+dropZone.addEventListener('drop', handleDrop, false);
+
+function handleDrop(e) {
+  const dt = e.dataTransfer;
+  const file = dt.files[0];
+  if (!file) return;
+  uploadPdf(file);
+}
+
+function uploadPdf(file) {
+  const formData = new FormData();
+  formData.append('pdf', file);
+  fetch('/api/ocr', { method: 'POST', body: formData })
+    .then(res => res.json())
+    .then(data => {
+      pages = data.pages || [];
+      renderPages();
+    })
+    .catch(err => console.error('Upload error', err));
+}
+
+function renderPages() {
+  results.innerHTML = '';
+  pages.forEach((text, i) => {
+    const div = document.createElement('div');
+    div.className = 'page-result';
+    div.innerHTML = `<h3>Page ${i + 1}</h3><pre>${text}</pre>`;
+    const actions = document.createElement('div');
+    actions.className = 'page-actions';
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = 'Copy MD';
+    copyBtn.onclick = () => navigator.clipboard.writeText(text);
+    const downloadBtn = document.createElement('button');
+    downloadBtn.textContent = 'Download MD';
+    downloadBtn.onclick = () => downloadText(`page_${i + 1}.md`, text);
+    actions.appendChild(copyBtn);
+    actions.appendChild(downloadBtn);
+    div.appendChild(actions);
+    results.appendChild(div);
+  });
+}
+
+function downloadText(filename, text) {
+  const blob = new Blob([text], {type: 'text/markdown'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+allDownloadBtn.onclick = function() {
+  if (!pages.length) return;
+  const zip = new JSZip();
+  pages.forEach((text, i) => zip.file(`page_${i + 1}.md`, text));
+  zip.generateAsync({type:'blob'}).then(blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'pages.zip';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>olmOCR Frontend</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+</head>
+<body>
+  <div id="drop-zone">Drop PDF here</div>
+  <div id="results"></div>
+  <button id="all-download">Download All</button>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
   <title>olmOCR Frontend</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
   <div id="drop-zone">Drop PDF here</div>

--- a/frontend/server.py
+++ b/frontend/server.py
@@ -1,8 +1,11 @@
 from flask import Flask, request, jsonify
 from pypdf import PdfReader
+import tempfile
 import io
 import os
 import asyncio
+import httpx
+from olmocr.data.renderpdf import render_pdf_to_base64png
 
 app = Flask(__name__, static_folder=os.path.dirname(__file__), static_url_path="")
 
@@ -10,14 +13,35 @@ app = Flask(__name__, static_folder=os.path.dirname(__file__), static_url_path="
 def root():
     return app.send_static_file('index.html')
 
-def _extract_pages(data: bytes):
+def _page_count(data: bytes) -> int:
+    """Return number of pages using PdfReader."""
     reader = PdfReader(io.BytesIO(data))
-    return [page.extract_text() or '' for page in reader.pages]
+    return len(reader.pages)
+
+
+async def _ocr_page(tmp_path: str, page_num: int) -> str:
+    """Call local OCR service on a single page image."""
+    # render the PDF page to base64 PNG using helper from olmocr
+    b64 = await asyncio.to_thread(render_pdf_to_base64png, tmp_path, page_num, 1024)
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.post("http://127.0.0.1:8888/api/ocr", json={"image": b64})
+            r.raise_for_status()
+            return r.json().get("markdown", "")
+    except Exception:
+        return ""
 
 
 async def _process_pdf(file):
     data = await asyncio.to_thread(file.read)
-    return await asyncio.to_thread(_extract_pages, data)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(data)
+    try:
+        page_total = await asyncio.to_thread(_page_count, data)
+        tasks = [_ocr_page(tmp.name, i + 1) for i in range(page_total)]
+        return await asyncio.gather(*tasks)
+    finally:
+        os.unlink(tmp.name)
 
 
 @app.route('/api/ocr', methods=['POST'])

--- a/frontend/server.py
+++ b/frontend/server.py
@@ -15,14 +15,18 @@ def _extract_pages(data: bytes):
     return [page.extract_text() or '' for page in reader.pages]
 
 
+async def _process_pdf(file):
+    data = await asyncio.to_thread(file.read)
+    return await asyncio.to_thread(_extract_pages, data)
+
+
 @app.route('/api/ocr', methods=['POST'])
-async def api_ocr():
+def api_ocr():
     file = request.files.get('pdf')
     if not file:
         return jsonify({'error': 'no file uploaded'}), 400
     try:
-        data = await asyncio.to_thread(file.read)
-        pages = await asyncio.to_thread(_extract_pages, data)
+        pages = asyncio.run(_process_pdf(file))
         return jsonify({'pages': pages})
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/frontend/server.py
+++ b/frontend/server.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify, send_from_directory
+from pypdf import PdfReader
+import io
+import os
+
+app = Flask(__name__, static_folder=os.path.dirname(__file__), static_url_path="")
+
+@app.route('/')
+def root():
+    return app.send_static_file('index.html')
+
+@app.route('/api/ocr', methods=['POST'])
+def api_ocr():
+    file = request.files.get('pdf')
+    if not file:
+        return jsonify({'error': 'no file uploaded'}), 400
+    try:
+        reader = PdfReader(file.stream)
+        pages = [page.extract_text() or '' for page in reader.pages]
+        return jsonify({'pages': pages})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(debug=True)
+

--- a/frontend/server.py
+++ b/frontend/server.py
@@ -1,7 +1,8 @@
-from flask import Flask, request, jsonify, send_from_directory
+from flask import Flask, request, jsonify
 from pypdf import PdfReader
 import io
 import os
+import asyncio
 
 app = Flask(__name__, static_folder=os.path.dirname(__file__), static_url_path="")
 
@@ -9,14 +10,19 @@ app = Flask(__name__, static_folder=os.path.dirname(__file__), static_url_path="
 def root():
     return app.send_static_file('index.html')
 
+def _extract_pages(data: bytes):
+    reader = PdfReader(io.BytesIO(data))
+    return [page.extract_text() or '' for page in reader.pages]
+
+
 @app.route('/api/ocr', methods=['POST'])
-def api_ocr():
+async def api_ocr():
     file = request.files.get('pdf')
     if not file:
         return jsonify({'error': 'no file uploaded'}), 400
     try:
-        reader = PdfReader(file.stream)
-        pages = [page.extract_text() or '' for page in reader.pages]
+        data = await asyncio.to_thread(file.read)
+        pages = await asyncio.to_thread(_extract_pages, data)
         return jsonify({'pages': pages})
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4,3 +4,4 @@ body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
 .page-actions { margin-top: 5px; }
 button { margin-right: 5px; }
 #all-download { margin-top: 20px; }
+.markdown { white-space: pre-wrap; }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+#drop-zone { border: 2px dashed #ccc; padding: 40px; text-align: center; color: #777; }
+.page-result { border: 1px solid #ccc; padding: 10px; margin-top: 10px; }
+.page-actions { margin-top: 5px; }
+button { margin-right: 5px; }
+#all-download { margin-top: 20px; }


### PR DESCRIPTION
## Summary
- restore `review.html` without Copy/Download buttons
- create a new `frontend` folder for standalone UI
- implement drag-and-drop PDF upload with per-page Copy/Download and zip-all in JS
- document the new frontend in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pypdf, torch, numpy, requests, botocore)*

------
https://chatgpt.com/codex/tasks/task_e_6850f594df74832c8de182cac914b5a7